### PR TITLE
0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently Linux has the best support, Windows is supported partially, macOS is n
 
 Since it's not possible to make this completely safe: memory leaks, UB can still happen (for example, due to some unsafe call to C library), you should only use unloading for development (see [live reload](https://github.com/xxshady/relib/tree/main/examples/README.md#live-reload) example). `relib` can also be used without unloading, see ["Usage without unloading"](https://docs.rs/relib/latest/relib/docs/index.html#usage-without-unloading).
 
-See [feature support matrix](https://docs.rs/relib/latest/relib/docs/index.html#feature-support-matrix) for what `relib` offers to improve unloading of dynamic libraries in Rust. And for what not, check out [limitations](#limitations).
+See [feature support matrix](https://docs.rs/relib/latest/relib/docs/index.html#feature-support-matrix) for what `relib` offers to improve unloading of dynamic libraries in Rust. And for what not, check out [caveats](#caveats).
 
 ## Examples
 
@@ -24,7 +24,7 @@ See [examples](https://github.com/xxshady/relib/tree/main/examples/README.md).
 
 See [`docs`](https://docs.rs/relib/latest/relib/docs/index.html) of `relib` crate.
 
-## Limitations
+## Caveats
 
 ### Imports/exports runtime validation
 
@@ -181,6 +181,10 @@ pub trait Exports {
   }
 }
 ```
+
+### Each module has its own standard library
+
+Each compiled module (.dll or .so) uses its own copy of standard library. Because of this, for example, [`std::thread::current().id()`](https://doc.rust-lang.org/stable/std/thread/fn.current.html) called in a module may return different id compared to the host, since each module has it's own thread id counter (in this particular case you can use [thread_id](https://docs.rs/thread-id) instead to get thread identifiers from operating system).
 
 ## Why dynamic libraries when we already have WASM?
 

--- a/docs.md
+++ b/docs.md
@@ -60,7 +60,7 @@ fn main() {
   // main function is unsafe to call (as well as any other module export) because these preconditions are not checked by relib:
   // 1. returned value must be actually `R` at runtime, for example you called this function with type bool but module returns i32.
   // 2. type of return value must be FFI-safe.
-  // 3. returned value must not be a reference-counting pointer (see limitations on main docs page/README).
+  // 3. returned value must not be a reference-counting pointer (see caveats on main docs page/README).
   let returned_value: Option<()> = unsafe {
     module.call_main::<()>()
   };
@@ -231,7 +231,7 @@ let module = unsafe {
 // 1. types of arguments and return value must be FFI-safe
 //    (you can use abi_stable or stabby crate for it, see "abi_stable_usage" example).
 // 2. host and module crates must be compiled with same shared crate code.
-// 3. returned value must not be a reference-counting pointer (see limitations on main docs page/README).
+// 3. returned value must not be a reference-counting pointer (see caveats on main docs page/README).
 let value = unsafe { gen_imports::foo() }; // gen_imports is defined by relib_interface::include_imports!()
 dbg!(value); // prints "value = 10"
 ```

--- a/examples/basic_host/src/main.rs
+++ b/examples/basic_host/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
   // main function is unsafe to call (as well as any other module export) because these preconditions are not checked by relib:
   // 1. returned value must be actually `R` at runtime, for example you called this function with type bool but module returns i32.
   // 2. type of return value must be FFI-safe.
-  // 3. returned value must not be a reference-counting pointer (see limitations on main docs page/README).
+  // 3. returned value must not be a reference-counting pointer (see caveats on main docs page/README).
   let returned_value: Option<()> = unsafe { module.call_main::<()>() };
 
   // if module panics while executing any export it returns None

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -54,7 +54,7 @@ mod windows;
 /// // main function is unsafe to call (as well as any other module export) because these pre-conditions are not checked by relib:
 /// // - Returned value must be actually `R` at runtime. For example if you called this function with type bool but module returns i32, UB will occur.
 /// // - Type of return value must be FFI-safe.
-/// // - Returned value must not be a reference-counting pointer (see limitations in README or docs page).
+/// // - Returned value must not be a reference-counting pointer (see caveats in README or docs page).
 /// let returned_value = unsafe { module.call_main::<()>() };
 ///
 /// // if module panics while executing any export it returns None

--- a/host/src/module.rs
+++ b/host/src/module.rs
@@ -81,7 +81,7 @@ impl<E: ModuleExportsForHost> Module<E> {
   /// Behavior is undefined if any of the following conditions are violated:
   /// 1. Returned value must be actually `R` at runtime. For example if you called this function with type `bool` but module returns `i32`, UB will occur.
   /// 2. Type of return value must be FFI-safe.
-  /// 3. Returned value must not be a reference-counting pointer (see [limitations](https://docs.rs/relib/latest/relib/#moving-non-copy-types-between-host-and-module)).
+  /// 3. Returned value must not be a reference-counting pointer (see [caveats](https://docs.rs/relib/latest/relib/#moving-non-copy-types-between-host-and-module)).
   ///
   /// # Panics
   /// If main function is not exported from the module.

--- a/host/src/unloading/module.rs
+++ b/host/src/unloading/module.rs
@@ -39,7 +39,7 @@ impl<E: ModuleExportsForHost> Module<E> {
       unsafe {
         self.internal_exports.lock_module_allocator();
         self.internal_exports.run_thread_local_dtors();
-        self.internal_exports.unmap_all_mmaps();
+        self.internal_exports.misc_cleanup();
       }
     }
 

--- a/interface/src/host.rs
+++ b/interface/src/host.rs
@@ -154,7 +154,7 @@ fn generate_exports(
             #inputs
           ) -> Option<#pub_return_type>
           {
-            /// All parameters must be Copy, see relib limitations in the readme for more info.
+            /// All parameters must be Copy, see relib caveats in the readme for more info.
             fn ____assert_type_is_copy____(_: impl Copy) {}
             #( ____assert_type_is_copy____( #inputs_without_types ); )*
 
@@ -317,7 +317,7 @@ fn generate_imports(
             #inputs
           ) -> std::mem::MaybeUninit<#return_type> // will be initialized if function won't panic
           {
-            /// All parameters must be Copy, see relib limitations in the readme for more info.
+            /// All parameters must be Copy, see relib caveats in the readme for more info.
             fn ____assert_type_is_copy____(_: impl Copy) {}
             #( ____assert_type_is_copy____( #inputs_without_types ); )*
 

--- a/interface/src/shared.rs
+++ b/interface/src/shared.rs
@@ -219,7 +219,7 @@ pub const SAFETY_DOC: &str = "# Safety\n\
   Behavior is undefined if any of the following conditions are violated:\n\
   1. Types of arguments and return value must be FFI-safe.\n\
   2. Host and module crates must be compiled with same shared crate code (which contains exports and imports traits).\n\
-  3. Returned value must not be a reference-counting pointer (see [limitations](https://docs.rs/relib/latest/relib/#moving-non-copy-types-between-host-and-module)).";
+  3. Returned value must not be a reference-counting pointer (see [caveats](https://docs.rs/relib/latest/relib/#moving-non-copy-types-between-host-and-module)).";
 
 pub fn type_needs_box(type_: &TokenStream2) -> bool {
   relib_internal_shared::type_needs_box(&type_.to_string())

--- a/module/src/unloading_core.rs
+++ b/module/src/unloading_core.rs
@@ -14,6 +14,8 @@ mod thread_spawn_hook;
 /// (for example, std backtrace leaks them)
 #[cfg(target_os = "linux")]
 mod mmap_hooks;
+#[cfg(target_os = "linux")]
+mod pthread_key_hooks;
 mod helpers;
 mod exports_impl;
 mod alloc_tracker;

--- a/module/src/unloading_core/exports_impl.rs
+++ b/module/src/unloading_core/exports_impl.rs
@@ -51,10 +51,11 @@ impl Exports for ModuleExportsImpl {
     }
   }
 
-  fn unmap_all_mmaps() {
+  fn misc_cleanup() {
     #[cfg(target_os = "linux")]
     {
-      super::mmap_hooks::unmap_all();
+      super::mmap_hooks::cleanup();
+      super::pthread_key_hooks::cleanup();
     }
     #[cfg(target_os = "windows")]
     {

--- a/module/src/unloading_core/mmap_hooks.rs
+++ b/module/src/unloading_core/mmap_hooks.rs
@@ -64,7 +64,7 @@ unsafe extern "C" fn munmap(addr: *mut c_void, len: libc::size_t) -> libc::c_int
   original_impl(addr, len)
 }
 
-pub fn unmap_all() {
+pub fn cleanup() {
   unsafe {
     let mmaps = std::mem::take(&mut *lock_mmaps());
     for (ptr, len) in mmaps {

--- a/module/src/unloading_core/pthread_key_hooks.rs
+++ b/module/src/unloading_core/pthread_key_hooks.rs
@@ -1,0 +1,74 @@
+use std::{
+  ffi::{c_int, c_uint, c_void},
+  sync::{
+    atomic::{AtomicBool, Ordering::Relaxed},
+    Mutex, MutexGuard,
+  },
+};
+
+use crate::unloading_core::helpers::unrecoverable;
+
+#[expect(non_camel_case_types)]
+type pthread_key_t = c_uint;
+type Dtor = Option<unsafe extern "C" fn(*mut c_void)>;
+type Store = Vec<(pthread_key_t, Dtor)>;
+
+static STORE: Mutex<Store> = Mutex::new(Vec::new());
+
+pub static EXIT_DELETE: AtomicBool = AtomicBool::new(false);
+
+pub fn lock_store() -> MutexGuard<'static, Store> {
+  STORE.lock().unwrap_or_else(|_| {
+    unrecoverable("failed to lock pthread keys store");
+  })
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C" fn pthread_key_create(key: *mut pthread_key_t, dtor: Dtor) -> c_int {
+  type OriginalImpl = unsafe extern "C" fn(key: *mut pthread_key_t, dtor: Dtor) -> c_int;
+
+  let original_impl: OriginalImpl =
+    std::mem::transmute(libc::dlsym(libc::RTLD_NEXT, c"pthread_key_create".as_ptr()));
+
+  let result = original_impl(key, dtor);
+
+  if result == 0 {
+    lock_store().push((*key, dtor));
+  }
+
+  result
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pthread_key_delete(key: pthread_key_t) -> c_int {
+  {
+    if !EXIT_DELETE.load(Relaxed) {
+      let mut store = lock_store();
+      let idx = store.iter().position(|&(key_, _)| key_ == key);
+      if let Some(idx) = idx {
+        store.swap_remove(idx);
+      }
+    }
+  }
+
+  type OriginalImpl = unsafe extern "C" fn(key: pthread_key_t) -> c_int;
+
+  let original_impl: OriginalImpl =
+    std::mem::transmute(libc::dlsym(libc::RTLD_NEXT, c"pthread_key_delete".as_ptr()));
+
+  original_impl(key)
+}
+
+pub fn cleanup() {
+  // TODO: use mutex instead?
+  EXIT_DELETE.store(true, Relaxed);
+
+  let pthread_keys = std::mem::take(&mut *lock_store());
+  // TODO: call dtor instead?
+  for (key, _dtor) in pthread_keys {
+    let r = unsafe { pthread_key_delete(key) };
+    if r != 0 {
+      unrecoverable("libc::pthread_key_delete failed");
+    }
+  }
+}

--- a/shared/src/exports.rs
+++ b/shared/src/exports.rs
@@ -12,7 +12,7 @@ pub trait ___Internal___Exports___ {
   // linux-only
   fn spawned_threads_count() -> u64;
   fn run_thread_local_dtors();
-  fn unmap_all_mmaps();
+  fn misc_cleanup();
 
   // windows-only
   fn set_dealloc_callback(callback: *const c_void);

--- a/testing/host/src/multiple_modules.rs
+++ b/testing/host/src/multiple_modules.rs
@@ -14,16 +14,6 @@ pub fn main() {
       });
     }
   });
-
-  // TODO: fix std::thread::current() https://github.com/xxshady/relib/issues/4
-  // thread::spawn(|| {
-  //   let module = load_module(&format!("test_module_0"));
-  //   unload_module(module);
-
-  //   thread::sleep(Duration::from_millis(1000));
-  // })
-  // .join()
-  // .unwrap();
 }
 
 fn unload_module<E: ModuleExportsForHost>(module: Module<E>) {

--- a/testing/module/src/multiple_modules.rs
+++ b/testing/module/src/multiple_modules.rs
@@ -1,8 +1,11 @@
 #[relib_module::export]
 pub fn main() {
-  println!("[module] thread id: {:?}", thread_id::get());
-
-  // TODO: std::thread::current() not working correctly and causes seg fault
-  // https://github.com/xxshady/relib/issues/4
-  // println!("[module] std thread id: {:?}", std::thread::current().id());
+  println!(
+    "[module] thread id: {:?} (using thread_id crate)",
+    thread_id::get()
+  );
+  println!(
+    "[module] std current thread id: {:?}",
+    std::thread::current().id()
+  );
 }


### PR DESCRIPTION
# Key changes

- Fixed `std::thread::current` [segfault](https://github.com/xxshady/relib/issues/4) on Linux
(by adding hooks of libc `pthread_key_create` and `pthread_key_delete`)
- Added some documentation about std copy in each module