### PR TITLE
0.4.2

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -10,13 +10,16 @@ description = "relib is a framework for reloadable dynamic libraries"
 
 [features]
 unloading = ["relib_interface/unloading", "dep:thread-id"]
+super_special_reinit_of_dbghelp = []
 
 [lints.clippy]
 unwrap_used = "forbid"
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(relib_docs)'] }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--generate-link-to-definition"]
+rustdoc-args = ["--generate-link-to-definition", "--cfg", "relib_docs"]
 
 [dependencies]
 libloading.workspace = true

--- a/host/src/helpers.rs
+++ b/host/src/helpers.rs
@@ -139,7 +139,7 @@ mod windows_impl {
   pub fn is_library_loaded(library_path: &str) -> bool {
     let library_path = str_to_wide_cstring(library_path);
 
-    let mut module = 0;
+    let mut module = std::ptr::null_mut();
     let flags = GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
     let r = unsafe { GetModuleHandleExW(flags, library_path.as_ptr(), &mut module) };
     r != 0

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -141,7 +141,20 @@ pub unsafe fn load_module<E: ModuleExportsForHost>(
 /// Panics on Windows if `dbghelp.dll` was already loaded (for example, by `backtrace` crate or standard library).
 pub unsafe fn init() {
   #[cfg(target_os = "windows")]
-  windows::dbghelp::try_init();
+  windows::dbghelp::try_init_standalone();
+}
+
+/// Don't use it unless you really need to.
+/// Forcibly terminates and reinitializes dbghelp.dll for backtraces on Windows.
+///
+/// # Safety
+/// God knows...
+///
+#[cfg(any(target_os = "windows", relib_docs))]
+#[cfg(feature = "super_special_reinit_of_dbghelp")]
+pub unsafe fn forcibly_reinit_dbghelp() {
+  #[cfg(target_os = "windows")]
+  windows::dbghelp::forcibly_reinit_dbghelp();
 }
 
 // TODO: fix it

--- a/host/src/windows.rs
+++ b/host/src/windows.rs
@@ -24,7 +24,7 @@ pub mod imports {
   pub const GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS: u32 = 0x00000004;
   pub const ERROR_INSUFFICIENT_BUFFER: u32 = 122;
 
-  windows_targets::link!("kernel32.dll" "system" fn GetModuleHandleExW(flags: u32, module_name: *const u16, module: *mut isize) -> BOOL);
+  windows_targets::link!("kernel32.dll" "system" fn GetModuleHandleExW(flags: u32, module_name: *const u16, module: *mut *mut isize) -> BOOL);
   windows_targets::link!("kernel32.dll" "system" fn GetModuleFileNameW(module: *const isize, file_name: PWSTR, size: DWORD) -> DWORD);
 
   windows_targets::link!("kernel32.dll" "system" fn GetCurrentProcess() -> HANDLE);
@@ -44,11 +44,11 @@ pub fn get_current_dylib() -> Option<PathBuf> {
   fn get_dylib_path(len: usize) -> Option<PathBuf> {
     let mut buf = Vec::with_capacity(len);
     unsafe {
-      let module_handle = std::ptr::null_mut();
+      let mut module_handle = std::ptr::null_mut();
       let flags =
         GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
 
-      let failed = GetModuleHandleExW(flags, get_dylib_path as *const _, module_handle) == 0;
+      let failed = GetModuleHandleExW(flags, get_dylib_path as *const _, &mut module_handle) == 0;
       if failed {
         None
       } else {

--- a/testing/host/src/backtrace_unloading_host_as_dylib.rs
+++ b/testing/host/src/backtrace_unloading_host_as_dylib.rs
@@ -6,7 +6,7 @@ use crate::shared::current_target_dir;
 
 pub fn main() {
   let target_dir = current_target_dir();
-  let path = format!("{target_dir}/{DLL_PREFIX}test_host_as_dylib{DLL_SUFFIX}");
+  let path = format!("{target_dir}/backtrace_unloading_host_as_dylib__host/{DLL_PREFIX}test_host_as_dylib{DLL_SUFFIX}");
 
   unsafe {
     let host = Library::new(path).unwrap();

--- a/testing/host_as_dylib/src/lib.rs
+++ b/testing/host_as_dylib/src/lib.rs
@@ -6,13 +6,7 @@ use test_host_shared::dylib_filename;
 
 #[no_mangle]
 pub extern "C" fn main() {
-  let filename = dylib_filename("test_module");
-  let path = format!("backtrace_unloading_host_as_dylib/{filename}");
-
-  dbg!();
-  let (module, _) = test_host_shared::load_module_with_path::<(), ()>((), &path, true);
-  unload_module(module);
-  dbg!();
+  testing_release_backtrace_in_host____();
 }
 
 fn unload_module<E: ModuleExportsForHost>(module: Module<E>) {
@@ -24,4 +18,16 @@ fn unload_module<E: ModuleExportsForHost>(module: Module<E>) {
       panic!("this branch must not be called");
     }
   }
+}
+
+#[inline(never)]
+#[unsafe(no_mangle)]
+fn testing_release_backtrace_in_host____() {
+  let filename = dylib_filename("test_module");
+  let path = format!("backtrace_unloading_host_as_dylib/{filename}");
+
+  dbg!();
+  let (module, _) = test_host_shared::load_module_with_path::<(), ()>((), &path, true);
+  unload_module(module);
+  dbg!();
 }

--- a/testing/module/Cargo.toml
+++ b/testing/module/Cargo.toml
@@ -29,7 +29,7 @@ multiple_modules = ["relib_module/unloading"]
 panic_in_interface_host = []
 panic_in_interface_module = []
 backtrace_unloading = ["relib_module/unloading"]
-backtrace_unloading_host_as_dylib = ["backtrace_unloading"]
+backtrace_unloading_host_as_dylib = ["relib_module/unloading"]
 is_already_loaded_error = ["relib_module/unloading"]
 dbghelp_is_already_loaded_init = []
 

--- a/testing/module/src/backtrace_unloading_host_as_dylib.rs
+++ b/testing/module/src/backtrace_unloading_host_as_dylib.rs
@@ -1,0 +1,37 @@
+use std::{backtrace::Backtrace, path::MAIN_SEPARATOR};
+
+#[relib_module::export]
+pub fn main() {
+  if cfg!(debug_assertions) {
+    let backtrace = Backtrace::force_capture();
+    let backtrace = format!("{backtrace}");
+    let s = MAIN_SEPARATOR;
+    assert!(
+      backtrace.contains(&format!(
+        "testing{s}module{s}src{s}backtrace_unloading_host_as_dylib.rs:6"
+      )),
+      "backtrace was:\n{backtrace}",
+    );
+    assert!(
+      backtrace.contains(&format!("testing{s}host_as_dylib{s}src{s}lib.rs:30")),
+      "backtrace was:\n{backtrace}",
+    );
+  } else {
+    #[inline(never)]
+    #[unsafe(no_mangle)]
+    fn testing_release_backtrace____() -> Backtrace {
+      Backtrace::force_capture()
+    }
+
+    let backtrace = testing_release_backtrace____();
+    let backtrace = format!("{backtrace}");
+    assert!(
+      backtrace.contains("testing_release_backtrace____"),
+      "backtrace was:\n{backtrace}"
+    );
+    assert!(
+      backtrace.contains("testing_release_backtrace_in_host____"),
+      "backtrace was:\n{backtrace}"
+    );
+  }
+}

--- a/testing/module/src/lib.rs
+++ b/testing/module/src/lib.rs
@@ -34,3 +34,6 @@ mod is_already_loaded_error;
 
 #[cfg(feature = "dbghelp_is_already_loaded_init")]
 mod dbghelp_is_already_loaded_init;
+
+#[cfg(feature = "backtrace_unloading_host_as_dylib")]
+mod backtrace_unloading_host_as_dylib;

--- a/testing/runner/src/backtrace_unloading_host_as_dylib.rs
+++ b/testing/runner/src/backtrace_unloading_host_as_dylib.rs
@@ -30,6 +30,63 @@ pub fn main() {
         failed: {e}"
       );
     });
+    fs::remove_file(&from).unwrap();
+  }
+
+  {
+    let filename = dylib_filename("test_host_as_dylib");
+    let dir = "target/debug";
+    let from = format!("{dir}/{filename}");
+    let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib__host");
+    let to = format!("{to_dir}/{filename}");
+    fs::create_dir_all(&to_dir).unwrap();
+    fs::copy(&from, &to).unwrap_or_else(|e| {
+      panic!(
+        "copy\n\
+        | {from}\n\
+        -> {to}\n\
+        failed: {e}"
+      );
+    });
+    fs::remove_file(&from).unwrap();
+  }
+
+  if cfg!(target_os = "windows") {
+    {
+      let filename = "test_module.pdb";
+      let dir = "target/debug";
+      let from = format!("{dir}/{filename}");
+      let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib");
+      let to = format!("{to_dir}/{filename}");
+      fs::create_dir_all(&to_dir).unwrap();
+      fs::copy(&from, &to).unwrap_or_else(|e| {
+        panic!(
+          "copy\n\
+          | {from}\n\
+          -> {to}\n\
+          failed: {e}"
+        );
+      });
+      fs::remove_file(&from).unwrap();
+    }
+
+    {
+      let filename = "test_host_as_dylib.pdb";
+      let dir = "target/debug";
+      let from = format!("{dir}/{filename}");
+      let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib__host");
+      let to = format!("{to_dir}/{filename}");
+      fs::create_dir_all(&to_dir).unwrap();
+      fs::copy(&from, &to).unwrap_or_else(|e| {
+        panic!(
+          "copy\n\
+      | {from}\n\
+      -> {to}\n\
+      failed: {e}"
+        );
+      });
+      fs::remove_file(&from).unwrap();
+    }
   }
   call_host_by_directory("debug");
 
@@ -49,6 +106,63 @@ pub fn main() {
         failed: {e}"
       );
     });
+    fs::remove_file(&from).unwrap();
+  }
+
+  {
+    let filename = dylib_filename("test_host_as_dylib");
+    let dir = "target/release";
+    let from = format!("{dir}/{filename}");
+    let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib__host");
+    let to = format!("{to_dir}/{filename}");
+    fs::create_dir_all(&to_dir).unwrap();
+    fs::copy(&from, &to).unwrap_or_else(|e| {
+      panic!(
+        "copy\n\
+        | {from}\n\
+        -> {to}\n\
+        failed: {e}"
+      );
+    });
+    fs::remove_file(&from).unwrap();
+  }
+
+  if cfg!(target_os = "windows") {
+    {
+      let filename = "test_module.pdb";
+      let dir = "target/release";
+      let from = format!("{dir}/{filename}");
+      let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib");
+      let to = format!("{to_dir}/{filename}");
+      fs::create_dir_all(&to_dir).unwrap();
+      fs::copy(&from, &to).unwrap_or_else(|e| {
+        panic!(
+          "copy\n\
+          | {from}\n\
+          -> {to}\n\
+          failed: {e}"
+        );
+      });
+      fs::remove_file(&from).unwrap();
+    }
+
+    {
+      let filename = "test_host_as_dylib.pdb";
+      let dir = "target/release";
+      let from = format!("{dir}/{filename}");
+      let to_dir = format!("{dir}/backtrace_unloading_host_as_dylib__host");
+      let to = format!("{to_dir}/{filename}");
+      fs::create_dir_all(&to_dir).unwrap();
+      fs::copy(&from, &to).unwrap_or_else(|e| {
+        panic!(
+          "copy\n\
+      | {from}\n\
+      -> {to}\n\
+      failed: {e}"
+        );
+      });
+      fs::remove_file(&from).unwrap();
+    }
   }
   call_host_by_directory("release");
 }


### PR DESCRIPTION
# Changes

- Fixed backtraces when host is a dll on Windows
- Fixed compilation mismatch load error (it could dead lock due to the early DllMain detach call)
- Added super_special_reinit_of_dbghelp™️exclusively for [altv-rust](https://github.com/xxshady/altv-rust)