### PR TITLE
0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Platforms supported
 
-Currently Linux has the best support, Windows is supported partially, macOS is not supported (not tested), see [support matrix](https://docs.rs/relib/latest/relib/docs/index.html#feature-support-matrix).
+Linux and Windows are fully supported, macOS is not supported (not tested), see [support matrix](https://docs.rs/relib/latest/relib/docs/index.html#feature-support-matrix).
 
 ## Overview
 
@@ -46,7 +46,7 @@ For ABI stable types, you can use abi_stable or stabby crate for it, see `abi_st
 
 ### Dead locks
 
-If your program deadlocks unloading won't work and you will have to kill the whole process.
+If your program (module) deadlocks unloading won't work and you will have to kill the whole process.
 
 ### Moving non-`Copy` types between host and module
 

--- a/docs.md
+++ b/docs.md
@@ -312,7 +312,7 @@ It's done using `#[global_allocator]` so if you want to set your own global allo
 | Memory deallocation [(?)](#memory-deallocation)            | ✅      | ✅                                   |
 | Panic handling [(?)](#panic-handling)                      | ✅      | ✅                                   |
 | Thread-locals                                              | ✅      | ✅                                   |
-| Background threads check [(?)](#background-threads-check)  | ✅      | ❌                                   |
+| Background threads check [(?)](#background-threads-check)  | ✅      | ✅                                   |
 | Final unload check [(?)](#final-unload-check)              | ✅      | ✅                                   |
 | Before load check [(?)](#before-load-check)                | ✅      | ✅                                   |
 | Backtraces [(?)](#backtraces)                              | ✅      | ✅                                   |

--- a/host/src/exports_types.rs
+++ b/host/src/exports_types.rs
@@ -1,4 +1,3 @@
-
 use libloading::Library;
 
 pub trait ModuleExportsForHost {

--- a/host/src/helpers.rs
+++ b/host/src/helpers.rs
@@ -27,6 +27,7 @@ pub fn open_library(path: &Path) -> Result<libloading::Library, crate::LoadError
     use libc::{RTLD_DEEPBIND, RTLD_LAZY, RTLD_LOCAL};
 
     // RTLD_DEEPBIND allows replacing __cxa_thread_atexit_impl (it's needed to call destructors of thread-locals)
+    // as well as mmap functions (to unmap leaked mappings) and thread spawn function (to check detached threads)
     // only for dynamic library without replacing it for the whole executable
     const FLAGS: i32 = RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND;
 

--- a/host/src/leak_library.rs
+++ b/host/src/leak_library.rs
@@ -13,7 +13,7 @@ impl LeakLibrary {
   }
 
   #[cfg(feature = "unloading")]
-  pub fn take(mut self) -> Library {
+  pub fn take(&mut self) -> Library {
     self.0.take().unwrap_or_else(|| unreachable!())
   }
 }

--- a/host/src/unloading.rs
+++ b/host/src/unloading.rs
@@ -2,10 +2,12 @@ mod module;
 mod errors;
 pub use errors::UnloadError;
 pub(crate) mod module_allocs;
-mod helpers;
+pub(crate) mod helpers;
 mod imports_impl;
 #[cfg(target_os = "windows")]
 mod windows_dealloc;
+#[cfg(target_os = "windows")]
+pub(crate) mod windows_thread_spawn_hook;
 
 relib_interface::include_exports!();
 relib_interface::include_imports!();

--- a/host/src/unloading/helpers.rs
+++ b/host/src/unloading/helpers.rs
@@ -17,3 +17,16 @@ fn unrecoverable_impl(message: &str) -> ! {
   eprintln!("aborting");
   std::process::abort();
 }
+
+#[cfg(target_os = "windows")]
+pub mod windows {
+  use libloading::{os::windows::Library as WindowsLibrary, Library};
+  use crate::module::WindowsLibraryHandle;
+
+  pub fn library_handle(library: Library) -> (Library, WindowsLibraryHandle) {
+    let handle = WindowsLibrary::from(library).into_raw();
+    let library = unsafe { WindowsLibrary::from_raw(handle) };
+    let library = Library::from(library);
+    (library, handle)
+  }
+}

--- a/host/src/unloading/module_allocs.rs
+++ b/host/src/unloading/module_allocs.rs
@@ -11,7 +11,7 @@ use super::{helpers::unrecoverable, InternalModuleExports};
 
 type Allocs = HashMap<ModuleId, HashMap<AllocatorPtr, Allocation>>;
 
-static ALLOCS: LazyLock<Mutex<Allocs>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+static ALLOCS: LazyLock<Mutex<Allocs>> = LazyLock::new(Default::default);
 
 fn lock_allocs() -> MutexGuard<'static, Allocs> {
   let Ok(allocs) = ALLOCS.lock() else {
@@ -37,10 +37,7 @@ pub fn remove_module(
 
   let mut allocs = lock_allocs();
   let Some(allocs) = allocs.remove(&module_id) else {
-    panic!(
-      "Failed to take allocs of module with module_id: {}",
-      module_id
-    );
+    panic!("Failed to take allocs of module with id: {module_id}");
   };
 
   // this check relies on two allocations in alloc tracker of the module,

--- a/host/src/unloading/windows_thread_spawn_hook.rs
+++ b/host/src/unloading/windows_thread_spawn_hook.rs
@@ -1,0 +1,133 @@
+use std::{
+  collections::HashMap,
+  ffi::c_void,
+  sync::{LazyLock, Mutex, MutexGuard, Once},
+};
+
+use minhook::MinHook;
+
+use crate::{
+  module::WindowsLibraryHandle,
+  windows::{
+    get_dylib_handle_from_addr,
+    imports::{CreateThread, HANDLE},
+  },
+};
+use super::{helpers::unrecoverable};
+
+type Payload = (
+  unsafe extern "system" fn(main: *mut c_void) -> u32,
+  *mut c_void,
+  WindowsLibraryHandle,
+);
+
+static mut ORIG: CreateThread = CreateThread;
+
+static INIT: Once = Once::new();
+
+type ModuleThreadsCount = HashMap<WindowsLibraryHandle, u64>;
+
+static MODULE_THREADS: LazyLock<Mutex<ModuleThreadsCount>> = LazyLock::new(Default::default);
+
+fn lock_module_threads() -> MutexGuard<'static, ModuleThreadsCount> {
+  let Ok(module_threads) = MODULE_THREADS.lock() else {
+    unrecoverable("failed to lock MODULE_THREADS");
+  };
+
+  module_threads
+}
+
+pub fn add_module(module_handle: WindowsLibraryHandle) {
+  let mut module_threads = lock_module_threads();
+  module_threads.insert(module_handle, 0);
+}
+
+pub fn remove_module(module_handle: WindowsLibraryHandle) -> Result<(), ()> {
+  let mut module_threads = lock_module_threads();
+  let Some(threads) = module_threads.remove(&module_handle) else {
+    panic!("Failed to remove module_threads of module with handle: {module_handle}");
+  };
+
+  if threads == 0 { Ok(()) } else { Err(()) }
+}
+
+pub unsafe fn init() {
+  INIT.call_once(|| {
+    let orig = unsafe { MinHook::create_hook(CreateThread as *mut c_void, hook as *mut c_void) };
+    let orig = orig.unwrap_or_else(|e| {
+      panic!("Failed to hook CreateThread: {e:?}");
+    });
+
+    // SAFETY: we are only writing to it once in this synchronized closure by std::sync::Once
+    unsafe {
+      ORIG = std::mem::transmute::<*mut c_void, CreateThread>(orig);
+    }
+  });
+}
+
+unsafe extern "system" fn hook(
+  lpthreadattributes: *const c_void,
+  dwstacksize: usize,
+  lpstartaddress: unsafe extern "system" fn(main: *mut c_void) -> u32,
+  lpparameter: *mut c_void,
+  dwcreationflags: u32,
+  lpthreadid: *mut u32,
+) -> HANDLE {
+  let module_handle = unsafe { get_dylib_handle_from_addr(lpstartaddress as *const _) };
+  if let Some(module_handle) = module_handle {
+    let module_handle = module_handle as WindowsLibraryHandle;
+
+    lock_module_threads()
+      .entry(module_handle)
+      .and_modify(|count| {
+        *count += 1;
+      });
+
+    let payload: Payload = (lpstartaddress, lpparameter, module_handle);
+    let payload = Box::new(payload);
+    let payload = Box::into_raw(payload);
+
+    unsafe {
+      ORIG(
+        lpthreadattributes,
+        dwstacksize,
+        thread_start,
+        payload as *mut c_void,
+        dwcreationflags,
+        lpthreadid,
+      )
+    }
+
+  // TODO: check if this branch is ever executed
+  } else {
+    unsafe {
+      ORIG(
+        lpthreadattributes,
+        dwstacksize,
+        lpstartaddress,
+        lpparameter,
+        dwcreationflags,
+        lpthreadid,
+      )
+    }
+  }
+}
+
+const _TYPE_ASSERT: CreateThread = hook;
+
+unsafe extern "system" fn thread_start(payload: *mut c_void) -> u32 {
+  // TODO: SAFETY
+  let (ret, module_handle) = unsafe {
+    let (f, value, module_handle) = *Box::from_raw(payload as *mut Payload);
+
+    (f(value), module_handle)
+  };
+
+  lock_module_threads()
+    .entry(module_handle)
+    .and_modify(|count| {
+      *count -= 1;
+    });
+
+  ret
+}

--- a/host/src/windows.rs
+++ b/host/src/windows.rs
@@ -1,5 +1,7 @@
 use std::{ffi::OsString, os::windows::ffi::OsStringExt, path::PathBuf};
 
+use minhook::MinHook;
+
 /// What does it solve:
 /// 1. Synchronizes dbghelp.dll between all modules: each module has it's own standard library and because of that sync
 ///    of dbghelp.dll in backtrace crate (which is used by std) doesn't work (dbghelp.dll is single-threaded)
@@ -29,6 +31,18 @@ pub mod imports {
 
   windows_targets::link!("kernel32.dll" "system" fn GetCurrentProcess() -> HANDLE);
   windows_targets::link!("kernel32.dll" "system" fn GetLastError() -> DWORD);
+
+  #[cfg(feature = "unloading")]
+  windows_targets::link!("kernel32.dll" "system" fn CreateThread(lpthreadattributes : *const c_void, dwstacksize : usize, lpstartaddress : unsafe extern "system" fn(main: *mut c_void) -> u32, lpparameter : *mut c_void, dwcreationflags : u32, lpthreadid : *mut u32) -> HANDLE);
+  #[cfg(feature = "unloading")]
+  pub type CreateThread = unsafe extern "system" fn(
+    lpthreadattributes: *const c_void,
+    dwstacksize: usize,
+    lpstartaddress: unsafe extern "system" fn(main: *mut c_void) -> u32,
+    lpparameter: *mut c_void,
+    dwcreationflags: u32,
+    lpthreadid: *mut u32,
+  ) -> HANDLE;
 }
 use imports::{
   GetLastError, GetModuleFileNameW, GetModuleHandleExW, DWORD, ERROR_INSUFFICIENT_BUFFER,
@@ -39,39 +53,47 @@ pub fn str_to_wide_cstring(str: &str) -> Vec<u16> {
   str.bytes().map(|b| b as u16).chain(Some(0)).collect()
 }
 
-// copy-pasted from process_path crate
 pub fn get_current_dylib() -> Option<PathBuf> {
   fn get_dylib_path(len: usize) -> Option<PathBuf> {
     let mut buf = Vec::with_capacity(len);
     unsafe {
-      let mut module_handle = std::ptr::null_mut();
-      let flags =
-        GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
-
-      let failed = GetModuleHandleExW(flags, get_dylib_path as *const _, &mut module_handle) == 0;
-      if failed {
+      let module_handle = get_dylib_handle_from_addr(get_dylib_path as *const _)?;
+      let ret = GetModuleFileNameW(module_handle, buf.as_mut_ptr(), len as DWORD) as usize;
+      if ret == 0 {
         None
+      } else if ret < len {
+        // Success, we need to trim trailing null bytes from the vec.
+        buf.set_len(ret);
+        let s = OsString::from_wide(&buf);
+        Some(s.into())
       } else {
-        let ret = GetModuleFileNameW(module_handle, buf.as_mut_ptr(), len as DWORD) as usize;
-        if ret == 0 {
-          None
-        } else if ret < len {
-          // Success, we need to trim trailing null bytes from the vec.
-          buf.set_len(ret);
-          let s = OsString::from_wide(&buf);
-          Some(s.into())
+        // The buffer might not be big enough so we need to check errno.
+        let errno = GetLastError();
+        if errno == ERROR_INSUFFICIENT_BUFFER {
+          get_dylib_path(len * 2)
         } else {
-          // The buffer might not be big enough so we need to check errno.
-          let errno = GetLastError();
-          if errno == ERROR_INSUFFICIENT_BUFFER {
-            get_dylib_path(len * 2)
-          } else {
-            None
-          }
+          None
         }
       }
     }
   }
 
   get_dylib_path(100)
+}
+
+pub unsafe fn get_dylib_handle_from_addr(addr: *const u16) -> Option<*mut isize> {
+  let mut module_handle = std::ptr::null_mut();
+
+  let flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
+  let ret = unsafe { GetModuleHandleExW(flags, addr, &mut module_handle) };
+
+  let failed = ret == 0;
+  if failed { None } else { Some(module_handle) }
+}
+
+pub unsafe fn enable_hooks() {
+  let res = unsafe { MinHook::enable_all_hooks() };
+  res.unwrap_or_else(|e| {
+    panic!("Failed to enable Windows related hooks: {e:?}");
+  });
 }

--- a/module/src/unloading_core.rs
+++ b/module/src/unloading_core.rs
@@ -21,6 +21,8 @@ mod exports_impl;
 mod alloc_tracker;
 pub use alloc_tracker::AllocTracker;
 #[cfg(target_os = "windows")]
+mod windows_dll_main;
+#[cfg(target_os = "windows")]
 mod windows_dealloc;
 
 /// Middleware for tracking all allocations to deallocate leaks

--- a/module/src/unloading_core/windows_dll_main.rs
+++ b/module/src/unloading_core/windows_dll_main.rs
@@ -1,0 +1,19 @@
+use std::ffi::c_void;
+
+use super::windows_dealloc;
+
+#[expect(clippy::upper_case_acronyms)]
+type BOOL = i32;
+pub const DLL_PROCESS_DETACH: u32 = 0;
+const TRUE: i32 = 1;
+
+#[unsafe(no_mangle)]
+unsafe extern "system" fn DllMain(
+  _module_handle: *mut c_void,
+  reason: u32,
+  lpv_reserved: *mut c_void,
+) -> BOOL {
+  windows_dealloc::on_dll_main_call(reason, lpv_reserved);
+
+  TRUE
+}

--- a/testing/host/Cargo.toml
+++ b/testing/host/Cargo.toml
@@ -26,6 +26,8 @@ backtrace_unloading_host_as_dylib = ["relib_host/unloading"]
 is_already_loaded_error = ["relib_host/unloading"]
 dbghelp_is_already_loaded_panic = []
 dbghelp_is_already_loaded_init = []
+windows_background_threads = ["relib_host/unloading"]
+windows_background_threads_fail = ["relib_host/unloading"]
 
 [dependencies]
 libloading.workspace = true

--- a/testing/host/src/backtrace_unloading_host_as_dylib.rs
+++ b/testing/host/src/backtrace_unloading_host_as_dylib.rs
@@ -6,7 +6,9 @@ use crate::shared::current_target_dir;
 
 pub fn main() {
   let target_dir = current_target_dir();
-  let path = format!("{target_dir}/backtrace_unloading_host_as_dylib__host/{DLL_PREFIX}test_host_as_dylib{DLL_SUFFIX}");
+  let path = format!(
+    "{target_dir}/backtrace_unloading_host_as_dylib__host/{DLL_PREFIX}test_host_as_dylib{DLL_SUFFIX}"
+  );
 
   unsafe {
     let host = Library::new(path).unwrap();

--- a/testing/host/src/main.rs
+++ b/testing/host/src/main.rs
@@ -14,6 +14,8 @@ mod backtrace_unloading_host_as_dylib;
 mod is_already_loaded_error;
 mod dbghelp_is_already_loaded_panic;
 mod dbghelp_is_already_loaded_init;
+mod windows_background_threads;
+mod windows_background_threads_fail;
 
 fn main() {
   if cfg!(feature = "unloading") {
@@ -47,6 +49,10 @@ fn main() {
     dbghelp_is_already_loaded_panic::main();
   } else if cfg!(feature = "dbghelp_is_already_loaded_init") {
     dbghelp_is_already_loaded_init::main();
+  } else if cfg!(feature = "windows_background_threads") {
+    windows_background_threads::main();
+  } else if cfg!(feature = "windows_background_threads_fail") {
+    windows_background_threads_fail::main();
   } else {
     panic!();
   }

--- a/testing/host/src/windows_background_threads.rs
+++ b/testing/host/src/windows_background_threads.rs
@@ -1,0 +1,71 @@
+use std::{thread, time::Duration};
+
+use cfg_if::cfg_if;
+
+use relib_host::{Module, ModuleExportsForHost};
+use crate::shared::{self, init_module_imports, ModuleExports};
+
+pub fn main() {
+  thread::scope(|s| {
+    let first_module_handle = s.spawn(move || {
+      let module = load_module("windows_background_threads__test_module_0");
+
+      unsafe {
+        module
+          .exports()
+          .spawn_background_threads(module.id, 3)
+          .unwrap();
+      }
+
+      thread::park();
+
+      unsafe {
+        module.exports().join_background_threads().unwrap();
+      }
+
+      unload_module(module);
+    });
+
+    // wait for threads of first module to spawn
+    thread::sleep(Duration::from_secs(1));
+
+    s.spawn(move || {
+      let module = load_module("windows_background_threads__test_module_1");
+      unsafe {
+        module
+          .exports()
+          .spawn_background_threads(module.id, 5)
+          .unwrap();
+      }
+
+      unsafe {
+        module.exports().join_background_threads().unwrap();
+      }
+
+      unload_module(module);
+    })
+    .join()
+    .unwrap();
+
+    first_module_handle.thread().unpark();
+  });
+}
+
+fn unload_module<E: ModuleExportsForHost>(module: Module<E>) {
+  cfg_if! {
+    if #[cfg(feature = "windows_background_threads")] {
+      let id = module.id;
+      module.unload().unwrap();
+      println!("{:?} unloaded module: {id}", std::thread::current().id());
+    } else {
+      drop(module);
+      panic!("this branch must not be called");
+    }
+  }
+}
+
+fn load_module(name: &str) -> Module<ModuleExports> {
+  let (module, _) =
+    shared::load_module_with_name::<ModuleExports, ()>(init_module_imports, name, true);
+  module
+}

--- a/testing/host/src/windows_background_threads_fail.rs
+++ b/testing/host/src/windows_background_threads_fail.rs
@@ -1,0 +1,38 @@
+use cfg_if::cfg_if;
+
+use relib_host::{Module, ModuleExportsForHost};
+use crate::shared::{self, init_module_imports, ModuleExports};
+
+pub fn main() {
+  let module = load_module("windows_background_threads__test_module_0");
+
+  unsafe {
+    module
+      .exports()
+      .spawn_background_threads(module.id, 3)
+      .unwrap();
+  }
+
+  unload_module(module);
+}
+
+fn unload_module<E: ModuleExportsForHost>(module: Module<E>) {
+  cfg_if! {
+    if #[cfg(feature = "windows_background_threads_fail")] {
+      use relib_host::UnloadError;
+
+      let Err(UnloadError::ThreadsStillRunning(_)) = dbg!(module.unload()) else {
+        unreachable!();
+      };
+    } else {
+      drop(module);
+      panic!("this branch must not be called");
+    }
+  }
+}
+
+fn load_module(name: &str) -> Module<ModuleExports> {
+  let (module, _) =
+    shared::load_module_with_name::<ModuleExports, ()>(init_module_imports, name, true);
+  module
+}

--- a/testing/host_shared/src/lib.rs
+++ b/testing/host_shared/src/lib.rs
@@ -66,7 +66,7 @@ pub fn current_target_dir() -> &'static str {
   }
 }
 
-// TODO: move it to some testing shared crate (see helpers of test_runner crate)
+// TODO: use libloading::library_filename?
 pub fn dylib_filename(name: &str) -> String {
   format!("{DLL_PREFIX}{name}{DLL_SUFFIX}")
 }

--- a/testing/module/Cargo.toml
+++ b/testing/module/Cargo.toml
@@ -32,6 +32,7 @@ backtrace_unloading = ["relib_module/unloading"]
 backtrace_unloading_host_as_dylib = ["relib_module/unloading"]
 is_already_loaded_error = ["relib_module/unloading"]
 dbghelp_is_already_loaded_init = []
+windows_background_threads = ["relib_module/unloading"]
 
 [dependencies]
 abi_stable.workspace = true

--- a/testing/module/src/lib.rs
+++ b/testing/module/src/lib.rs
@@ -37,3 +37,6 @@ mod dbghelp_is_already_loaded_init;
 
 #[cfg(feature = "backtrace_unloading_host_as_dylib")]
 mod backtrace_unloading_host_as_dylib;
+
+#[cfg(feature = "windows_background_threads")]
+mod windows_background_threads;

--- a/testing/module/src/windows_background_threads.rs
+++ b/testing/module/src/windows_background_threads.rs
@@ -1,0 +1,2 @@
+#[relib_module::export]
+pub fn main() {}

--- a/testing/runner/src/helpers.rs
+++ b/testing/runner/src/helpers.rs
@@ -60,7 +60,7 @@ pub fn call_host_by_directory(directory: &str) {
   host_bin();
 }
 
-// TODO: move it to some testing shared crate (see host_shared crate)
+// TODO: use libloading::library_filename?
 pub fn dylib_filename(name: &str) -> String {
   format!("{DLL_PREFIX}{name}{DLL_SUFFIX}")
 }

--- a/testing/runner/src/main.rs
+++ b/testing/runner/src/main.rs
@@ -37,6 +37,7 @@ fn main() {
 
   backtrace_unloading_host_as_dylib::main();
 
+  #[cfg(target_os = "windows")]
   windows_background_threads::main();
 
   println!();

--- a/testing/runner/src/main.rs
+++ b/testing/runner/src/main.rs
@@ -4,6 +4,8 @@ mod code_change;
 mod multiple_modules;
 mod panic_in_interface_host;
 mod backtrace_unloading_host_as_dylib;
+#[cfg(target_os = "windows")]
+mod windows_background_threads;
 
 const TEST_FEATURES: &[&str] = &[
   #[cfg(target_os = "windows")]
@@ -34,6 +36,8 @@ fn main() {
   panic_in_interface_host::main();
 
   backtrace_unloading_host_as_dylib::main();
+
+  windows_background_threads::main();
 
   println!();
   println!();

--- a/testing/runner/src/panic_in_interface_host.rs
+++ b/testing/runner/src/panic_in_interface_host.rs
@@ -20,8 +20,10 @@ pub fn main() {
     let stderr = String::from_utf8(output.stderr).unwrap();
     println!("stderr:\n{stderr}");
 
-    assert!(stderr
-      .contains(r#"[relib] host panicked while executing import "panic" of module, aborting"#));
+    assert!(
+      stderr
+        .contains(r#"[relib] host panicked while executing import "panic" of module, aborting"#)
+    );
     dbg!(output.status);
     assert!(!output.status.success());
   };

--- a/testing/runner/src/windows_background_threads.rs
+++ b/testing/runner/src/windows_background_threads.rs
@@ -1,0 +1,43 @@
+use std::fs;
+
+use crate::helpers::{call_host_by_directory, cmd};
+
+pub fn main() {
+  // ------------------------- windows_background_threads
+  let (build_debug, build_release) = cmd!(
+    "cargo",
+    "build",
+    "--workspace",
+    "--features",
+    "windows_background_threads"
+  );
+
+  build_debug();
+  run_modules("debug");
+  build_release();
+  run_modules("release");
+
+  // ------------------------- windows_background_threads_fail
+  let (build_debug, build_release) = cmd!(
+    "cargo",
+    "build",
+    "--workspace",
+    "--features",
+    "windows_background_threads_fail"
+  );
+  build_debug();
+  call_host_by_directory("debug");
+  build_release();
+  call_host_by_directory("release");
+}
+
+fn run_modules(directory: &str) {
+  for idx in 0..2 {
+    fs::copy(
+      format!("target/{directory}/test_module.dll"),
+      format!("target/{directory}/windows_background_threads__test_module_{idx}.dll"),
+    )
+    .unwrap();
+  }
+  call_host_by_directory(directory);
+}

--- a/testing/shared/src/exports.rs
+++ b/testing/shared/src/exports.rs
@@ -36,4 +36,8 @@ pub trait Exports {
   fn call_imports();
 
   fn only_called_once() -> bool;
+
+  // background threads check on windows
+  fn spawn_background_threads(module_id: u64, how_many: u8);
+  fn join_background_threads();
 }


### PR DESCRIPTION
Implemented background threads check for Windows, and thus the gap between linux and windows in feature support is closed, at least for now (closes #13)

Also added one more safety condition in `relib_host::load_module` as consequence