### PR TITLE
fix thread-safety of module loading

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -37,31 +37,31 @@ windows-targets = "0.53.0"
 minhook = "0.6.0"
 
 [dependencies.relib_internal_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../interface"
 features = ["include"]
 
 [dependencies.relib_internal_crate_compilation_info]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../crate_compilation_info"
 features = ["normal"]
 
 [build-dependencies]
 
 [build-dependencies.relib_interface]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../interface"
 features = ["internal", "build"]
 
 [build-dependencies.relib_internal_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [build-dependencies.relib_internal_crate_compilation_info]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../crate_compilation_info"
 features = ["build"]

--- a/host/src/helpers.rs
+++ b/host/src/helpers.rs
@@ -1,7 +1,10 @@
 use std::{
   mem::{needs_drop, MaybeUninit},
   path::Path,
-  sync::atomic::{AtomicU64, Ordering},
+  sync::{
+    atomic::{AtomicU64, Ordering},
+    Mutex,
+  },
 };
 
 use relib_internal_shared::ModuleId;
@@ -181,3 +184,6 @@ fn warn_if_type_needs_drop_without_post<R>(export_name: &str, export_has_post_fn
 pub fn path_to_str(path: &Path) -> &str {
   path.to_str().expect("library path must be UTF-8 string")
 }
+
+pub static LIBRARY_LOADING_GUARD: Mutex<LibraryLoadingGuard> = Mutex::new(LibraryLoadingGuard);
+pub struct LibraryLoadingGuard;

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -30,7 +30,7 @@ rustdoc-args = ["--generate-link-to-definition"]
 
 [dependencies.relib_internal_shared]
 optional = true
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.prettyplease]

--- a/module/Cargo.toml
+++ b/module/Cargo.toml
@@ -32,38 +32,38 @@ optional = true
 workspace = true
 
 [dependencies.relib_export]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../export"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true
 
 [dependencies.relib_internal_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../interface"
 features = ["include"]
 
 [dependencies.relib_internal_crate_compilation_info]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../crate_compilation_info"
 features = ["normal"]
 
 [build-dependencies]
 
 [build-dependencies.relib_interface]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../interface"
 features = ["internal", "build"]
 
 [build-dependencies.relib_internal_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [build-dependencies.relib_internal_crate_compilation_info]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../crate_compilation_info"
 features = ["build"]

--- a/testing/host/Cargo.toml
+++ b/testing/host/Cargo.toml
@@ -28,6 +28,7 @@ dbghelp_is_already_loaded_panic = []
 dbghelp_is_already_loaded_init = []
 windows_background_threads = ["relib_host/unloading"]
 windows_background_threads_fail = ["relib_host/unloading"]
+parallel_module_loading = []
 
 [dependencies]
 libloading.workspace = true

--- a/testing/host/Cargo.toml
+++ b/testing/host/Cargo.toml
@@ -35,27 +35,27 @@ abi_stable.workspace = true
 cfg-if.workspace = true
 
 [dependencies.test_host_shared]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../host_shared"
 
 [dependencies.relib_host]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../host"
 
 [dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["include"]
 
 [build-dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["build"]
 
 [build-dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"

--- a/testing/host/src/main.rs
+++ b/testing/host/src/main.rs
@@ -16,6 +16,7 @@ mod dbghelp_is_already_loaded_panic;
 mod dbghelp_is_already_loaded_init;
 mod windows_background_threads;
 mod windows_background_threads_fail;
+mod parallel_module_loading;
 
 fn main() {
   if cfg!(feature = "unloading") {
@@ -53,6 +54,8 @@ fn main() {
     windows_background_threads::main();
   } else if cfg!(feature = "windows_background_threads_fail") {
     windows_background_threads_fail::main();
+  } else if cfg!(feature = "parallel_module_loading") {
+    parallel_module_loading::main();
   } else {
     panic!();
   }

--- a/testing/host/src/parallel_module_loading.rs
+++ b/testing/host/src/parallel_module_loading.rs
@@ -1,0 +1,28 @@
+use std::sync::atomic::{AtomicBool, Ordering::SeqCst};
+
+use relib_host::LoadError;
+use crate::shared::{self, init_module_imports, ModuleExports};
+
+static SECOND_CALL: AtomicBool = AtomicBool::new(false);
+
+pub fn main() {
+  std::thread::scope(|s| {
+    for _ in 1..=300 {
+      s.spawn(move || {
+        let res = shared::load_module_with_result::<ModuleExports, ()>(init_module_imports, true);
+
+        let load_module_already_called = SECOND_CALL.load(SeqCst);
+        match (res, load_module_already_called) {
+          (Ok(_), false) => {
+            SECOND_CALL.store(true, SeqCst);
+          }
+          (Err(LoadError::ModuleAlreadyLoaded), _) => {}
+          (Ok(_), true) => {
+            panic!("LoadError::ModuleAlreadyLoaded must be returned on second call to load_module");
+          }
+          (Err(e), _) => unreachable!("{e:?}"),
+        }
+      });
+    }
+  });
+}

--- a/testing/host_as_dylib/Cargo.toml
+++ b/testing/host_as_dylib/Cargo.toml
@@ -19,27 +19,27 @@ libloading.workspace = true
 cfg-if.workspace = true
 
 [dependencies.test_host_shared]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../host_shared"
 
 [dependencies.relib_host]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../host"
 
 [dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["include"]
 
 [build-dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["build"]
 
 [build-dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"

--- a/testing/host_shared/Cargo.toml
+++ b/testing/host_shared/Cargo.toml
@@ -12,23 +12,23 @@ publish = false
 libloading.workspace = true
 
 [dependencies.relib_host]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../host"
 
 [dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["include"]
 
 [build-dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["build"]
 
 [build-dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"

--- a/testing/module/Cargo.toml
+++ b/testing/module/Cargo.toml
@@ -33,7 +33,7 @@ backtrace_unloading_host_as_dylib = ["relib_module/unloading"]
 is_already_loaded_error = ["relib_module/unloading"]
 dbghelp_is_already_loaded_init = []
 windows_background_threads = ["relib_module/unloading"]
-stdout_sync = []
+parallel_module_loading = []
 
 [dependencies]
 abi_stable.workspace = true

--- a/testing/module/Cargo.toml
+++ b/testing/module/Cargo.toml
@@ -33,6 +33,7 @@ backtrace_unloading_host_as_dylib = ["relib_module/unloading"]
 is_already_loaded_error = ["relib_module/unloading"]
 dbghelp_is_already_loaded_init = []
 windows_background_threads = ["relib_module/unloading"]
+stdout_sync = []
 
 [dependencies]
 abi_stable.workspace = true
@@ -40,23 +41,23 @@ cfg-if.workspace = true
 thread-id.workspace = true
 
 [dependencies.relib_module]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../module"
 
 [dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"
 
 [dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["include"]
 
 [build-dependencies.relib_interface]
-version = "0.6.1"
+version = "=0.6.1"
 path = "../../interface"
 features = ["build"]
 
 [build-dependencies.test_shared]
-version = "=0.6.0"
+version = "=0.6.1"
 path = "../shared"

--- a/testing/module/src/lib.rs
+++ b/testing/module/src/lib.rs
@@ -40,3 +40,6 @@ mod backtrace_unloading_host_as_dylib;
 
 #[cfg(feature = "windows_background_threads")]
 mod windows_background_threads;
+
+#[cfg(feature = "parallel_module_loading")]
+mod parallel_module_loading;

--- a/testing/module/src/parallel_module_loading.rs
+++ b/testing/module/src/parallel_module_loading.rs
@@ -1,0 +1,2 @@
+#[relib_module::export]
+pub fn main() {}

--- a/testing/runner/src/main.rs
+++ b/testing/runner/src/main.rs
@@ -8,6 +8,7 @@ mod backtrace_unloading_host_as_dylib;
 mod windows_background_threads;
 
 const TEST_FEATURES: &[&str] = &[
+  "parallel_module_loading",
   #[cfg(target_os = "windows")]
   "dbghelp_is_already_loaded_init",
   #[cfg(target_os = "windows")]


### PR DESCRIPTION
This code could result in loading of the same .dll/.so multiple times, now [`LoadError::ModuleAlreadyLoaded`](https://docs.rs/relib_host/latest/relib_host/enum.LoadError.html#variant.ModuleAlreadyLoaded) should always be returned in other threads 

```rs
// doesn't matter if unloading feature disabled or enabled
std::thread::scope(|s| {
  s.spawn(|| {
    unsafe {
      let _ = relib_host::load_module::<...>(...);
    }
  });
  
  s.spawn(|| {
    unsafe {
      let _ = relib_host::load_module::<...>(...);
    }
  });
});
```